### PR TITLE
Fix GAE calculation

### DIFF
--- a/actor_critic_improved_fixed.py
+++ b/actor_critic_improved_fixed.py
@@ -355,12 +355,12 @@ class OptimizedActorCriticAgent:
         gae = 0
         
         for t in reversed(range(len(rewards))):
-            if t == len(rewards) - 1:
-                next_value = 0 if dones[t] else next_values[t]
-            else:
-                next_value = values[t + 1]
-            
-            delta = rewards[t] + self.gamma * next_value * (1 - dones[t]) - values[t]
+            # Use the estimated value of the next state provided to this
+            # function. When the current step is terminal, there is no
+            # bootstrap value so we set it to 0.
+            next_value = 0 if dones[t] else next_values[t]
+
+            delta = rewards[t] + self.gamma * next_value - values[t]
             gae = delta + self.gamma * self.gae_lambda * (1 - dones[t]) * gae
             advantages[t] = gae
         


### PR DESCRIPTION
## Summary
- fix bug in `_compute_gae` using `next_values[t]` instead of `values[t+1]`
- handle episode boundaries with zero bootstrap

## Testing
- `python - <<'PY'
from racetrack_env import RacetrackEnv
from actor_critic_improved_fixed import OptimizedActorCriticAgent
env = RacetrackEnv(track_size=(32,17), max_speed=5)
agent = OptimizedActorCriticAgent(env, buffer_size=10)
agent.train(n_episodes=1, verbose=False)
print("done")
PY` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68405bf4963c833188006e9da0d2e774